### PR TITLE
Must use addressable gem before 2.3 to avoid array param bug

### DIFF
--- a/springboard-retail.gemspec
+++ b/springboard-retail.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency 'patron', '>= 0.4.18'
-  s.add_runtime_dependency 'addressable', '>= 2.2.8'
+  s.add_runtime_dependency 'addressable', '~> 2.2.8'
   s.add_runtime_dependency 'json', '>= 1.7.4'
   s.add_runtime_dependency 'hashie'
 


### PR DESCRIPTION
Starting with addressable 2.3, passing arrays as query values is no longer supported, which breaks this behavior in the Springboard Gem.
