### PR TITLE
Add only method to return select fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ resource.sort(:description, :created_at).filter(:active => true).each do |item|
 end
 ```
 
+### Returning select fields
+Resources have a `only` method that accepts any number of field keys to return only the selected fields. Note that each call to `only` overwrites any previous fields.
+
+```ruby
+resource.only(:id)
+resource.only(:public_id, :updated_at)
+
+# returns a new resource for chaining:
+resource.only(:public_id, :updated_at).filter(:active => true).each do |item|
+  # ...
+end
+```
+
 ### Creating Resources
 
 Create a new resource via POST:

--- a/lib/springboard/client/collection.rb
+++ b/lib/springboard/client/collection.rb
@@ -80,6 +80,19 @@ module Springboard
       end
 
       ##
+      # Returns a new resource with the given fields added to the query string as _only parameters.
+      #
+      # @example
+      #    resource.only('id', :public_id)
+      #
+      # @param [#to_s] returns One or more fields
+      #
+      # @return [Resource]
+      def only(*fields)
+        query('_only' => fields)
+      end
+
+      ##
       # Performs a request to get the first result of the first page of the 
       # collection and returns it.
       #

--- a/spec/springboard/client/resource_spec.rb
+++ b/spec/springboard/client/resource_spec.rb
@@ -97,6 +97,16 @@ describe Springboard::Client::Resource do
     end
   end
 
+  describe "only" do
+    it "should set the _only parameter based on the given values" do
+      expect(resource.only('f1', 'f2').uri.query).to eq('_only[]=f1&_only[]=f2')
+    end
+
+    it "should replace the existing _only parameters" do
+      expect(resource.only('f1').only('f2', 'f3').uri.query).to eq('_only[]=f2&_only[]=f3')
+    end
+  end
+
   %w{count each each_page}.each do |method|
     describe method do
       it "should call the client's #{method} method with the resource's URI" do


### PR DESCRIPTION
Adds the new API param _only to the Ruby client allowing you to select only certain fields for a resource. This allows you to fetch more relevant information at once instead of fetching all details for each resource.