### PR TITLE
Prevent count and first methods from modifying the resource

### DIFF
--- a/lib/springboard/client.rb
+++ b/lib/springboard/client.rb
@@ -199,19 +199,6 @@ module Springboard
       end
     end
 
-    ##
-    # Returns a count of subordinate resources of the given collection resource
-    # URI.
-    #
-    # @param [#to_s] uri
-    # @raise [RequestFailed] If the GET fails
-    # @return [Integer] The subordinate resource count
-    def count(uri)
-      uri = URI.parse(uri)
-      uri.merge_query_values! 'page' => 1, 'per_page' => 1
-      get!(uri)['total']
-    end
-
     private
 
     def prepare_request_body(body)

--- a/lib/springboard/client/collection.rb
+++ b/lib/springboard/client/collection.rb
@@ -31,7 +31,8 @@ module Springboard
       #
       # @return [Integer] The subordinate resource count
       def count
-        call_client(:count)
+        response = clone.query(:per_page => 1, :page => 1).get!
+        response[:total]
       end
 
       ##
@@ -100,7 +101,7 @@ module Springboard
       #
       # @return [Body] The first entry in the response :results array
       def first
-        response = query(:per_page => 1, :page => 1).get!
+        response = clone.query(:per_page => 1, :page => 1).get!
         response[:results].first
       end
 

--- a/spec/springboard/client/resource_spec.rb
+++ b/spec/springboard/client/resource_spec.rb
@@ -107,7 +107,7 @@ describe Springboard::Client::Resource do
     end
   end
 
-  %w{count each each_page}.each do |method|
+  %w{each each_page}.each do |method|
     describe method do
       it "should call the client's #{method} method with the resource's URI" do
         expect(client).to receive(method).with(resource.uri)
@@ -134,6 +134,27 @@ describe Springboard::Client::Resource do
     end
   end
 
+  describe "count" do
+    let(:response_data) {
+      {
+        :status => 200,
+        :body => {:total => 123}.to_json
+      }
+    }
+
+    it "should not set the per_page query string param to 1" do
+      request_stub = stub_request(:get, "#{base_url}/some/path?page=1&per_page=1").to_return(response_data)
+      resource.count
+      expect(request_stub).to have_been_requested
+      expect(resource.uri.to_s).to eq('/some/path')
+    end
+
+    it "should return the total count for the requested resource" do
+      request_stub = stub_request(:get, "#{base_url}/some/path?page=1&per_page=1").to_return(response_data)
+      expect(resource.count).to eq(123)
+    end
+  end
+
   describe "first" do
     let(:response_data) {
       {
@@ -142,10 +163,11 @@ describe Springboard::Client::Resource do
       }
     }
 
-    it "should set the per_page query string param to 1" do
+    it "should not set the per_page query string param to 1" do
       request_stub = stub_request(:get, "#{base_url}/some/path?page=1&per_page=1").to_return(response_data)
       resource.first
       expect(request_stub).to have_been_requested
+      expect(resource.uri.to_s).to eq('/some/path')
     end
 
     it "should return the first element of the :results array" do

--- a/spec/springboard/client_spec.rb
+++ b/spec/springboard/client_spec.rb
@@ -239,14 +239,4 @@ describe Springboard::Client do
       end.to yield_successive_args(*all_results)
     end
   end
-
-  describe "count" do
-    it "should request the first page/record of the collection and return the total" do
-      response = double(Springboard::Client::Response)
-      allow(response).to receive(:[]).with('total').and_return(17)
-      expect(client).to receive(:get!).with("/things?page=1&per_page=1".to_uri)
-        .and_return(response)
-      expect(client.count('/things')).to eq(17)
-    end
-  end
 end


### PR DESCRIPTION
Make the first and count methods return the result without mutating the original resource

Currently, the count and first methods modify your original resource causing unexpected results. For instance if you make a resource such as `items = springboard[:items].query(per_page: 500)` and then fetch a count of that resource for something such as initializing a progress bar with `items.count`, the original items resource is now mutated and overwritten to only 1 per page.