### PR TITLE
Make dup method clone URI to prevent unwanted mutation

### DIFF
--- a/lib/springboard/client/uri.rb
+++ b/lib/springboard/client/uri.rb
@@ -10,7 +10,7 @@ module Springboard
       #
       # @return [URI]
       def self.parse(value)
-        return value if value.is_a?(self)
+        return value.dup if value.is_a?(self)
         new(::Addressable::URI.parse(value))
       end
 
@@ -28,6 +28,14 @@ module Springboard
       # @return [URI]
       def initialize(uri)
         @uri = uri
+      end
+
+      ##
+      # Clones the URI object
+      #
+      # @return [URI]
+      def dup
+        self.class.new(@uri.dup)
       end
 
       ##

--- a/spec/springboard/client/uri_spec.rb
+++ b/spec/springboard/client/uri_spec.rb
@@ -12,10 +12,39 @@ describe Springboard::Client::URI do
   end
 
   describe "parse" do
-    it "should return a URI based on the given string" do
-      uri = described_class.parse('/some_path')
-      expect(uri).to be_a(described_class)
-      expect(uri.to_s).to eq('/some_path')
+    describe "when called with a URI object" do
+      it "should return a cloned URI object" do
+        parsed_uri = described_class.parse(uri)
+        expect(uri.class).to eq(parsed_uri.class)
+        expect(uri.object_id).not_to eq(parsed_uri.object_id)
+        expect(parsed_uri.to_s).to eq(uri.to_s)
+      end
+    end
+
+    describe "when called with a URI string" do
+      it "should return a URI based on the given string" do
+        uri = described_class.parse('/some_path')
+        expect(uri).to be_a(described_class)
+        expect(uri.to_s).to eq('/some_path')
+      end
+    end
+  end
+
+  describe "dup" do
+    it "should return a duplicate URI object" do
+      dup_uri = uri.dup
+      expect(uri.class).to eq(dup_uri.class)
+      expect(uri.to_s).to eq(dup_uri.to_s)
+      expect(uri.object_id).not_to eq(dup_uri.object_id)
+    end
+
+    describe "when mutating the copy" do
+      it "should not affect the original" do
+        dup_uri = uri.dup
+        dup_uri.query_values = {per_page: 1}
+        expect(uri.to_s).to eq('/relative/path')
+        expect(dup_uri.to_s).to eq('/relative/path?per_page=1')
+      end
     end
   end
 


### PR DESCRIPTION
Calling query, each, each_page, or count were mutating the original URI because it was not being cloned during the dup process. This ensures the URI is cloned to prevent unwanted mutation to the original URI